### PR TITLE
Fix postrm

### DIFF
--- a/debian/zfswatcher.postrm
+++ b/debian/zfswatcher.postrm
@@ -30,7 +30,7 @@ case "$1" in
 esac
 
 if [ "$1" = "purge" ] ; then
-	rm -r /var/log/zfswatcher.log*
+	rm -f /var/log/zfswatcher.log*
 	rm -f /var/run/zfswatcher.pid
 fi
 


### PR DESCRIPTION
If the package cannot be configured due to missing dependencies it is left in state 'c' in aptitude, but postrm will not work.
